### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <jacoco-plugin.version>0.8.2</jacoco-plugin.version>
         <awaitility.version>3.0.0</awaitility.version>
         <resilience4j.version>0.13.2</resilience4j.version>
-        <log4j2.version>2.16.0</log4j2.version> <!-- Workaround for CVE-2021-44228 -->
+        <log4j2.version>2.17.0</log4j2.version> <!-- Workaround for CVE-2021-44228 -->
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <jacoco-plugin.version>0.8.2</jacoco-plugin.version>
         <awaitility.version>3.0.0</awaitility.version>
         <resilience4j.version>0.13.2</resilience4j.version>
-        <log4j2.version>2.17.0</log4j2.version> <!-- Workaround for CVE-2021-44228 -->
+        <log4j2.version>2.17.0</log4j2.version> <!-- Workaround for CVE-2021-45105-->
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     </properties>
 


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105