### PR TITLE
Update GitHub Actions workflow to the most recent ones and fix caching

### DIFF
--- a/.github/workflows/pr-functional-tests.yml
+++ b/.github/workflows/pr-functional-tests.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           cache: 'maven'
           java-version: ${{ matrix.java }}
 

--- a/.github/workflows/pr-functional-tests.yml
+++ b/.github/workflows/pr-functional-tests.yml
@@ -20,20 +20,13 @@ jobs:
         java: [ 11 ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          cache: 'maven'
           java-version: ${{ matrix.java }}
-
-      - name: Cache Maven dependendcies
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
 
       - name: Build with Maven
         run: mvn -B verify -DskipUnitTests=true --file pom.xml

--- a/.github/workflows/pr-java-ci.yml
+++ b/.github/workflows/pr-java-ci.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           cache: 'maven'
           java-version: ${{ matrix.java }}
 

--- a/.github/workflows/pr-java-ci.yml
+++ b/.github/workflows/pr-java-ci.yml
@@ -20,20 +20,13 @@ jobs:
         java: [ 11 ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          cache: 'maven'
           java-version: ${{ matrix.java }}
-
-      - name: Cache Maven dependendcies
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml


### PR DESCRIPTION
Adding Temurin as a Java distribution as this is now a mandatory field. Temurin is an old AdoptOpenJDK and is a part of the Eclipse foundation.