### PR TITLE
cross-repo issue creation

### DIFF
--- a/.github/workflows/cross-repo-issue.yml
+++ b/.github/workflows/cross-repo-issue.yml
@@ -1,0 +1,28 @@
+name: Cross-repo Issue Creation
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - "master"
+
+jobs:
+  cross-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.XREPO_APP_ID }}
+          private_key: ${{ secrets.XREPO_PEM }}
+      - name: create issue in other repo
+        if: "!contains(github.event.pull_request.labels.*.name, 'do not port') && github.event.pull_request.merged"
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          echo -e "A PR was merged over on PBC-Java\n\n- [https://github.com/prebid/prebid-cache-java/pull/${{github.event.number}}](https://github.com/prebid/prebid-cache-java/pull/${{github.event.number}})\n- timestamp: ${{ github.event.pull_request.merged_at}}" > msg
+          export msg=$(cat msg)
+          gh issue create --repo prebid/prebid-cache --title "Port PR from PBC-Java: ${{ github.event.pull_request.title }}" \
+              --body "$msg" \
+              --label auto


### PR DESCRIPTION
This is the process change we've been discussing, having github automatically open an issue in one repo when a PR is merged to its twin. Starting with PBC as a test, the idea would be to put versions of this workflow script in all 4 PBS/PBC repos

This has been created over in pbc-go already