### PR TITLE
Core: upgrade testcontainers-java to 1.19.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <kotest.version>5.8.0</kotest.version>
         <kotlin.version>1.9.22</kotlin.version>
         <kotlinx-coroutines-core-jvm.version>1.8.0</kotlinx-coroutines-core-jvm.version>
-        <testcontainers.version>1.19.6</testcontainers.version>
+        <testcontainers.version>1.19.8</testcontainers.version>
         <mockserver-client.version>5.15.0</mockserver-client.version>
         <ktor.version>2.3.8</ktor.version>
         <jackson-kotlin-module.version>2.16.1</jackson-kotlin-module.version>


### PR DESCRIPTION
Version 1.19.8 is the latest release of testcontainers-java
