### PR TITLE
Add default secondary cache timeout property

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,7 @@ cache:
   clients_cache_duration: 86400
   clients_cache_size: 1000
   host_param_protocol: https
+  secondary_cache_timeout_ms: 5000
 
 storage:
   redis: {}


### PR DESCRIPTION
This is a followup to the https://github.com/prebid/prebid-cache-java/pull/162