### PR TITLE
Aerospike: Expose minConnsPerNode property

### DIFF
--- a/src/main/java/org/prebid/cache/repository/aerospike/AerospikePropertyConfiguration.java
+++ b/src/main/java/org/prebid/cache/repository/aerospike/AerospikePropertyConfiguration.java
@@ -44,6 +44,7 @@ public class AerospikePropertyConfiguration {
     private int socketTimeout;
     private int totalTimeout;
     private int connectTimeout;
+    private int minConnsPerNode;
 
     private static final int DEFAULT_PORT = 3000;
 
@@ -92,6 +93,7 @@ public class AerospikePropertyConfiguration {
     ClientPolicy clientPolicy() {
         ClientPolicy clientPolicy = new ClientPolicy();
         clientPolicy.eventLoops = eventLoops();
+        clientPolicy.minConnsPerNode = minConnsPerNode;
         return clientPolicy;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -126,6 +126,7 @@ spring:
     socket_timeout: 30000
     total_timeout: 1000
     connect_timeout: 0
+    min_conns_per_node: 0
 
 ---
 # dev


### PR DESCRIPTION
Can be accessed by changing either `min_conns_per_node` or `min-conns-per-node` config properties