### PR TITLE
Set default Aerospike connection params

### DIFF
--- a/src/main/java/org/prebid/cache/repository/aerospike/AerospikePropertyConfiguration.java
+++ b/src/main/java/org/prebid/cache/repository/aerospike/AerospikePropertyConfiguration.java
@@ -42,9 +42,9 @@ public class AerospikePropertyConfiguration {
     private int maxRetry;
     private String namespace;
     private boolean preventUUIDDuplication;
-    private int socketTimeout;
-    private int totalTimeout;
-    private int connectTimeout;
+    private int socketTimeout = 30000;
+    private int totalTimeout = 1000;
+    private int connectTimeout = 0;
     private int minConnsPerNode;
     private int maxConnsPerNode = 100;
     private Replica readPolicy = Replica.SEQUENCE;


### PR DESCRIPTION
Set the default Aerospike client values to the default so that the host company doesn't need to provide their own unless actually needed.