### PR TITLE
Update pom.xml: remove unsupported element

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,6 @@
                     <configuration>
                         <!-- Project rooted path to CheckStyle configuration file. -->
                         <configLocation>checkstyle.xml</configLocation>
-                        <encoding>UTF-8</encoding>
                         <consoleOutput>true</consoleOutput>
                         <!-- true if project build should fails on any style violation. -->
                         <failsOnError>true</failsOnError>


### PR DESCRIPTION
It gets rid of the warning
```
[WARNING] Parameter 'encoding' is unknown for plugin 'maven-checkstyle-plugin:3.3.0:checkstyle (default)'
```
when building